### PR TITLE
Ability to call a function in the pre-require block

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,6 +51,15 @@ module.exports = function (grunt) {
           usePromises: true
         }
       },
+      prerequire: {
+        src: ['test/prerequire.js'],
+        options: {
+          usePhantom: true,
+          prerequire: function (context) {
+            context.foo = 'bar';
+          }
+        }
+      },
       sauce: {
         src: ['test/sanity.js'],
         options: {

--- a/tasks/lib/mocha-runner.js
+++ b/tasks/lib/mocha-runner.js
@@ -12,6 +12,9 @@ module.exports = function (opts, fileGroup, browser, grunt, onTestFinish) {
 
   mocha.suite.on('pre-require', function (context, file, m) {
     this.ctx.browser = browser;
+    if (opts.prerequire) {
+      opts.prerequire.call(this, context, file, m);
+    }
   });
 
   grunt.file.expand({filter: 'isFile'}, fileGroup.src).forEach(function (f) {

--- a/test/prerequire.js
+++ b/test/prerequire.js
@@ -1,0 +1,9 @@
+var assert = require('assert');
+
+describe('When a function is passed as a `prerequire` option', function () {
+
+  it('calls the function with the mocha runner context', function () {
+    assert.equal(foo, 'bar');
+  });
+
+});


### PR DESCRIPTION
Adds the ability to pass a function in the task options that is called
in the pre-require block of the mocha runner.

I find that this can be useful to set up the mocha environment. For example, if I want to include Chai in all of my tests:

``` javascript
mochaWebdriver: {
  test: {
    options: {
      usePhantom: true,
      prerequire: function (context) {
        context.expect = Chai.expect;
        context.assert = Chai.assert;
        Chai.should();
      }
    },
    src: ['test/**/*.js']
  }
}
```

You could also just pass a module:

``` javascript
prerequire: require('test/setup.js')
```

**Edit Forgot to say, the option can be called something different than `prerequire` if there's something you'd rather have it be!**
