### PR TITLE
added tunnelFlags options

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,7 +8,6 @@ module.exports = function (grunt) {
       options: {
         curly: true,
         eqeqeq: true,
-        es5: true,
         immed: true,
         indent: 2,
         latedef: true,
@@ -72,6 +71,19 @@ module.exports = function (grunt) {
           ]
         }
       },
+      tunnelOptions: {
+        src: ['test/tunnelOptions.js'],
+        options: {
+          // changing log file to sauce_connect.log.custom
+          tunnelFlags: ['-l', 'sauce_connect.log.custom'],
+          testName: 'sauce tunnel flags test',
+          concurrency: 2,
+          usePromises: true,
+          browsers: [
+            {browserName: 'internet explorer', platform: 'Windows 7', version: '9'}
+          ]
+        }
+       },
       saucePromises: {
         src: ['test/promiseAPi.js'],
         options: {
@@ -125,8 +137,10 @@ module.exports = function (grunt) {
                                 'mochaWebdriver:promises',
                                 'mochaWebdriver:requires',
                                 'mochaWebdriver:sauce',
+                                'mochaWebdriver:tunnelOptions',
                                 'mochaWebdriver:saucePromises'
                               ]);
-  grunt.registerTask('testSelenium', ['mochaWebdriver:selenium', 'mochaWebdriver:seleniumPromises']); 
+
+  grunt.registerTask('testSelenium', ['mochaWebdriver:selenium', 'mochaWebdriver:seleniumPromises']);
   grunt.registerTask('default', ['jshint', 'test']);
 };

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ to run tests against phantom, simply add the `usePhantom` flag to the options ha
 The plugin defaults to hitting port 4444, but you can specify your own port via
 the `phantomPort` option.
 
+###Using grunt-mocha-webdriver with your own Selenium server
+ In version 0.9.15 and later, You can run your tests against your own Selenium server instance.
+ To do so, use ``hostname`` and ``port`` options.
+ Don't forget to remove ``username`` and ``key``.
+ Note that the Selenium server should be started and ready before starting the tests.
+
 ##Documentation
 Run this task with the `mochaWebdriver` grunt command. For this plugin, the Grunt
 `src` property will specify which test files should be run with Mocha in
@@ -106,6 +112,16 @@ Type: String
 
 The Sauce Labs API key to use. Defaults to value of env var `SAUCE_ACCESS_KEY`.
 
+####hostname
+Type: String
+ 
+If specified, it will connect that selenium server instead of ondemand.saucelabs.com.
+ 
+####port
+Type: Int
+
+Selenium server port. Should be used in conjonction with ``hostname``.
+
 ####identifier
 Type: Number
 
@@ -117,10 +133,10 @@ Type: Int
 
 The number of concurrent browser sessions to spin up on Sauce Labs. Defaults to 1.
 
-####tunnelTimeout
-Type: Number
-
-Time to wait before closing all tunnels.
+####tunnelFlags
+Type: Array
+An array of option flags for Sauce Connect. See the list of available options
+ [here](https://saucelabs.com/docs/connect#connect-flags).
 
 ####testName
 Type: String
@@ -137,8 +153,8 @@ Type: [Object]
 
 An array of objects specifying which browser options should be passed to Sauce Labs.
 Unless a test is run against Phantom (e.g. `usePhantom` is true), this option
-*must* be specified. Each browser hash should specify: `browserName`, `platform`,
-and `version`.
+*must* be specified. Each browser hash should specify: `browserName`. For saucelabs tests, `platform`,
+and `version` are also required.
 
 ##Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
   "dependencies": {
     "wd": "~0.2.3",
     "async": "~0.2.8",
-    "mocha": "~1.15.1",
-    "sauce-tunnel": "~1.1"
+    "mocha": "~1.16.2",
+    "sauce-tunnel": "~1.1.2"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.7.2",
-    "phantomjs": "~1.9.2-1"
+    "grunt-contrib-jshint": "~0.8.0",
+    "phantomjs": "~1.9.2"
   },
   "peerDependencies": {
     "grunt": "~0.4.0",

--- a/tasks/grunt-mocha-wd.js
+++ b/tasks/grunt-mocha-wd.js
@@ -24,7 +24,8 @@ module.exports = function (grunt) {
       identifier: Math.floor((new Date()).getTime() / 1000 - 1230768000).toString(),
       concurrency: 1,
       testName: "",
-      testTags: []
+      testTags: [],
+      tunnelFlags: null
     });
 
     grunt.util.async.forEachSeries(this.files, function (fileGroup, next) {
@@ -188,7 +189,7 @@ module.exports = function (grunt) {
 
   function runTestsOnSaucelabs(fileGroup, opts, next) {
     if (opts.browsers) {
-      var tunnel = new SauceTunnel(opts.username, opts.key, opts.identifier, true, opts.tunnelTimeout);
+      var tunnel = new SauceTunnel(opts.username, opts.key, opts.identifier, true, opts.tunnelFlags);
       configureLogEvents(tunnel);
 
       grunt.log.writeln("=> Connecting to Saucelabs ...");

--- a/tasks/lib/mocha-sauce-reporter.js
+++ b/tasks/lib/mocha-sauce-reporter.js
@@ -34,7 +34,7 @@ module.exports = function (browser) {
       }
       if (failures) {
         console.log(color('fail', '%d %s'), failures, 'tests failed.');
-        for(i in failInfo) {
+        for(var i in failInfo) {
           console.log(color('fail', i + '\n\t' + failInfo[i].join('\n\t')));
         }
       }

--- a/test/requires.js
+++ b/test/requires.js
@@ -1,3 +1,5 @@
+/*global globalVar:false*/
+
 var assert = require('assert');
 
 describe('A Mocha test run by grunt-mocha-sauce', function () {

--- a/test/tunnelOptions.js
+++ b/test/tunnelOptions.js
@@ -1,0 +1,17 @@
+var assert = require('assert'),
+    fs = require('fs'),
+    path = require('path');
+
+describe('Tunnel option flags', function () {
+
+  
+  it('should perform as expected', function (done) {
+    var searchBox;
+    var browser = this.browser;
+    browser.get('http://google.com')
+      .then(function() {
+        assert(fs.existsSync(path.join(__dirname, '../sauce_connect.log.custom')), 'custom log file does not exist');
+      })
+      .then(done, done);
+  });
+});


### PR DESCRIPTION
Hi,
Here is a pull request that allows to pass tunnel option flags through grunt `tunnelFlags` option.

I also:
- removed `tunnelTimeout` as it is no longer supported by latest sauce-tunnel package,
- updated npm packages listed in package.json
- updated the README.md (I also added hostname and port option description that I forgot to add in my previous pull request)

Thanks,

Saad

(sorry for the previous pull request, my branch was too messy...)
