### PR TITLE
Add stack traces to sauce reporter

### DIFF
--- a/tasks/lib/mocha-sauce-reporter.js
+++ b/tasks/lib/mocha-sauce-reporter.js
@@ -26,7 +26,7 @@ module.exports = function (browser) {
         e.title + 
         (e.err.message ? (': ' + e.err.message) : '') + 
         (e.err.stack ? e.err.stack : '')
-	  );      
+      );      
     });
 
     runner.on('end', function(){


### PR DESCRIPTION
Having the stack in the reporter makes it much easier to pinpoint issues.

Before this change:

```
Tests complete for firefox 26 on Windows 8.1
3 tests run.
2 tests passed.
1 tests failed.
User profile page
    should allow user to save: Object [object Promise] has no method 'indexOf'
Test video at: http://saucelabs.com/tests/123fbef4418aa6b7b616e53e32
```

After this change:

```
Tests complete for firefox 26 on Windows 8.1
3 tests run.
2 tests passed.
1 tests failed.
User profile page
    should allow user to save: Object [object Promise] has no method 'indexOf'
    at include (/Users/jdoe/dev/foo/node_modules/chai/lib/chai/core/assertions.js:150:14)
    at assert (/Users/jdoe/dev/foo/node_modules/chai/lib/chai/utils/addChainableMethod.js:66:31)
    at originalMethod (/Users/jdoe/dev/foo/node_modules/chai-as-promised/lib/chai-as-promised.js:271:69)
    at doAsserterAsyncAndAddThen (/Users/jdoe/dev/foo/node_modules/chai-as-promised/lib/chai-as-promised.js:293:33)
    at Assertion.addChainableMethod.originalGetter (/Users/jdoe/dev/foo/node_modules/chai-as-promised/lib/chai-as-promised.js:273:25)
    at assert (/Users/jdoe/dev/foo/node_modules/chai/lib/chai/utils/addChainableMethod.js:66:31)
    at Context.<anonymous> (/Users/jdoe/dev/foo/uifw/ui/integration_test/test/profile-spec.js:142:25)
    at Context._wrappedFn (/Users/jdoe/dev/foo/node_modules/mocha-as-promised/mocha-as-promised.js:118:41)
    at Test.Runnable.run (/Users/jdoe/dev/foo/node_modules/grunt-mocha-webdriver/node_modules/mocha/lib/runnable.js:194:15)
    at Runner.runTest (/Users/jdoe/dev/foo/node_modules/grunt-mocha-webdriver/node_modules/mocha/lib/runner.js:372:10)
Test video at: http://saucelabs.com/tests/123fbef4418aa6b7b616e53e32
```
