### PR TITLE
added phantomjs capabilities option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -43,6 +43,19 @@ module.exports = function (grunt) {
           phantomPort: 5555
         }
       },
+      phantomCapabilities: {
+        src: ['test/phantom-capabilities.js'],
+        options: {
+          testName: 'phantom capabilities test',
+          usePhantom: true,
+          phantomPort: 5555,
+          usePromises: true,
+          // see https://github.com/detro/ghostdriver
+          phantomCapabilities: {
+            'phantomjs.page.settings.userAgent': 'customUserAgent'
+          }
+        }
+      },
       promises: {
         src: ['test/promiseAPi.js'],
         options: {
@@ -145,6 +158,7 @@ module.exports = function (grunt) {
 
   // Default task.
   grunt.registerTask('test', [  'mochaWebdriver:phantom',
+                                'mochaWebdriver:phantomCapabilities',
                                 'mochaWebdriver:promises',
                                 'mochaWebdriver:requires',
                                 'mochaWebdriver:sauce',

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ Type: Int (Default: 4444)
 if testing against PhantomJS with the `usePhantom` flag, specify the port
 to test against.
 
+####phantomCapabilities
+Type: Object (Default: {})
+
+if testing against PhantomJS with the `usePhantom` flag, specify the
+[browser capabilities](https://github.com/detro/ghostdriver#what-extra-webdriver-capabilities-ghostdriver-offers).
+
 ####usePromises
 Type: Boolean
 

--- a/tasks/grunt-mocha-wd.js
+++ b/tasks/grunt-mocha-wd.js
@@ -26,7 +26,8 @@ module.exports = function (grunt) {
       testName: "",
       testTags: [],
       tunnelFlags: null,
-      secureCommands: false
+      secureCommands: false,
+      phantomCapabilities: {}
     });
 
     grunt.util.async.forEachSeries(this.files, function (fileGroup, next) {
@@ -67,7 +68,7 @@ module.exports = function (grunt) {
   function runTestsOnPhantom(fileGroup, opts, next) {
     var browser;
     var phantomPort = opts.phantomPort? opts.phantomPort : 4444;
-
+    var phantomCapabilities = opts.phantomCapabilities;
     if (opts.usePromises) {
       browser = wd.promiseChainRemote({port: phantomPort});
     }
@@ -78,7 +79,7 @@ module.exports = function (grunt) {
 
     startPhantom(phantomPort, opts.ignoreSslErrors, function (err, phantomProc) {
       if (err) { return next(err); }
-      browser.init({}, function () {
+      browser.init(phantomCapabilities, function () {
         runTestsForBrowser(opts, fileGroup, browser, function (err) {
           phantomProc.on('close', function () {
             grunt.log.writeln('Phantom exited.');

--- a/test/phantom-capabilities.js
+++ b/test/phantom-capabilities.js
@@ -1,0 +1,20 @@
+var assert = require('assert'),
+    fs = require('fs'),
+    path = require('path');
+
+describe('Phantomjs browser', function () {
+
+  
+  it('should allow to pass phantomjs capabilities', function (done) {
+    var searchBox;
+    var browser = this.browser;
+    browser.get('http://whatsmyua.com/')
+      .elementByCssSelector('.ua.success')
+      .text()
+      .then(function(txt) {
+        assert(/customUserAgent/.test(txt));
+      })
+      .then(done, done);
+  });
+});
+

--- a/test/sanity.js
+++ b/test/sanity.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var async = require('async');
 
-describe('A Mocha test run by grunt-mocha-sauce', function () {
+describe('A Mocha test run by grunt-mocha-webdriver', function () {
 
   it('has a browser injected into it', function () {
     assert.ok(this.browser);


### PR DESCRIPTION
Hi,

I added `phantomCapabilities` option which allows to pass phantomjs capabilities as defined [here](https://github.com/detro/ghostdriver#what-extra-webdriver-capabilities-ghostdriver-offers).

For example, you can:
- disable javascript, 
- change the user-agent header sent to the server,
- add username and password used for basic authentication, 
- customize any request headers
- ...

Thanks,

Saad
