### PR TITLE
updated wd, mocha and grunt-contrib-jshint

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "wd": "0.2.3 - 0.2.10",
+    "wd": "~0.2.17",
     "async": "~0.2.10",
-    "mocha": "~1.16.2",
+    "mocha": "~1.18.2",
     "sauce-tunnel": "~2.0.1"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.8.0",
+    "grunt-contrib-jshint": "~0.10.0",
     "phantomjs": "~1.9.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
The issue we had with wd > 0.2.10 seems to be fixed now (latest 0.2.17). So I updated the deps and devDeps. (see https://david-dm.org/jmreidy/grunt-mocha-webdriver#info=dependencies&view=table)

Note: I tried to update async, but npm complains about it so I left it as is:

``
`
npm WARN unmet dependency /Users/saadtazi/Projects/grunt-mocha-webdriver/node_modules/wd requires async@'~0.2.9' but will load
npm WARN unmet dependency /Users/saadtazi/Projects/grunt-mocha-webdriver/node_modules/async,
npm WARN unmet dependency which is version 0.7.0

```
```
