### PR TITLE
added phantomFlags option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,6 +57,18 @@ module.exports = function (grunt) {
           }
         }
       },
+      phantomFlag: {
+        src: ['test/phantom-flags.js'],
+        options: {
+          testName: 'phantom flags test',
+          usePhantom: true,
+          phantomPort: 5555,
+          usePromises: true,
+          phantomFlags: [
+            '--webdriver-logfile', 'phantom.log'
+          ]
+        }
+      },
       promises: {
         src: ['test/promiseAPi.js'],
         options: {

--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ Type: Object (Default: {})
 if testing against PhantomJS with the `usePhantom` flag, specify the
 [browser capabilities](https://github.com/detro/ghostdriver#what-extra-webdriver-capabilities-ghostdriver-offers).
 
+####phantomFlags
+Type: array (Default: [])
+
+if testing against PhantomJS with the `usePhantom` command-line options, specify start additional flags to use. Check [here](http://phantomjs.org/api/command-line.html) or type `phantomjs -h` for complete list of flags.
+
 ####usePromises
 Type: Boolean
 

--- a/tasks/grunt-mocha-wd.js
+++ b/tasks/grunt-mocha-wd.js
@@ -27,7 +27,8 @@ module.exports = function (grunt) {
       testTags: [],
       tunnelFlags: null,
       secureCommands: false,
-      phantomCapabilities: {}
+      phantomCapabilities: {},
+      phantomFlags: []
     });
 
     grunt.util.async.forEachSeries(this.files, function (fileGroup, next) {
@@ -81,7 +82,7 @@ module.exports = function (grunt) {
     }
     grunt.log.writeln('Running webdriver tests against PhantomJS.');
 
-    startPhantom(phantomPort, opts.ignoreSslErrors, function (err, phantomProc) {
+    startPhantom(phantomPort, opts, function (err, phantomProc) {
       if (err) { return next(err); }
       browser.init(phantomCapabilities, function () {
         runTestsForBrowser(opts, fileGroup, browser, function (err) {
@@ -96,9 +97,10 @@ module.exports = function (grunt) {
 
   }
 
-  function startPhantom(port, ignoreSslErrors, next) {
-    var phantomOpts = ['--webdriver', port];
-    if (ignoreSslErrors) {
+  function startPhantom(port, opts, next) {
+    var phantomOpts = opts.phantomFlags || [];
+    phantomOpts.push('--webdriver', port);
+    if (opts.ignoreSslErrors) {
       phantomOpts.push('--ignore-ssl-errors', 'yes');
     }
     var process = childProcess.execFile(phantom.path, phantomOpts);

--- a/test/phantom-flags.js
+++ b/test/phantom-flags.js
@@ -1,0 +1,21 @@
+var assert = require('assert'),
+    fs = require('fs'),
+    path = require('path');
+
+describe('Phantomjs browser', function () {
+
+  after(function() {
+    fs.unlinkSync('phantom.log');
+  });
+  
+  it('should allow to pass phantomjs start flags', function (done) {
+    var searchBox;
+    var browser = this.browser;
+    browser.get('http://www.google.com')
+      .then(function() {
+        assert.ok(fs.statSync('phantom.log').isFile());
+      })
+      .nodeify(done);
+  });
+});
+


### PR DESCRIPTION
I added a way to pass phantomjs command-line options.

Here is the current list... (from `phantomjs -h`):

```
  --cookies-file=<val>                 Sets the file name to store the persistent cookies
  --config=<val>                       Specifies JSON-formatted configuration file
  --debug=<val>                        Prints additional warning and debug message: 'true' or 'false' (default)
  --disk-cache=<val>                   Enables disk cache: 'true' or 'false' (default)
  --ignore-ssl-errors=<val>            Ignores SSL errors (expired/self-signed certificate errors): 'true' or 'false' (default)
  --load-images=<val>                  Loads all inlined images: 'true' (default) or 'false'
  --local-storage-path=<val>           Specifies the location for offline local storage
  --local-storage-quota=<val>          Sets the maximum size of the offline local storage (in KB)
  --local-to-remote-url-access=<val>   Allows local content to access remote URL: 'true' or 'false' (default)
  --max-disk-cache-size=<val>          Limits the size of the disk cache (in KB)
  --output-encoding=<val>              Sets the encoding for the terminal output, default is 'utf8'
  --remote-debugger-port=<val>         Starts the script in a debug harness and listens on the specified port
  --remote-debugger-autorun=<val>      Runs the script in the debugger immediately: 'true' or 'false' (default)
  --proxy=<val>                        Sets the proxy server, e.g. '--proxy=http://proxy.company.com:8080'
  --proxy-auth=<val>                   Provides authentication information for the proxy, e.g. ''-proxy-auth=username:password'
  --proxy-type=<val>                   Specifies the proxy type, 'http' (default), 'none' (disable completely), or 'socks5'
  --script-encoding=<val>              Sets the encoding used for the starting script, default is 'utf8'
  --web-security=<val>                 Enables web security, 'true' (default) or 'false'
  --ssl-protocol=<val>                 Sets the SSL protocol (supported protocols: 'SSLv3' (default), 'SSLv2', 'TLSv1', 'any')
  --ssl-certificates-path=<val>        Sets the location for custom CA certificates (if none set, uses system default)
  --webdriver=<val>                    Starts in 'Remote WebDriver mode' (embedded GhostDriver): '[[<IP>:]<PORT>]' (default '127.0.0.1:8910')
  --webdriver-logfile=<val>            File where to write the WebDriver's Log (default 'none') (NOTE: needs '--webdriver')
  --webdriver-loglevel=<val>           WebDriver Logging Level: (supported: 'ERROR', 'WARN', 'INFO', 'DEBUG') (default 'INFO') (NOTE: needs '--webdriver')
  --webdriver-selenium-grid-hub=<val>  URL to the Selenium Grid HUB: 'URL_TO_HUB' (default 'none') (NOTE: needs '--webdriver')
```
