### PR TITLE
report mocha test failures to correct test strategy

### DIFF
--- a/tasks/grunt-mocha-wd.js
+++ b/tasks/grunt-mocha-wd.js
@@ -47,11 +47,15 @@ module.exports = function (grunt) {
 
   function runTestsForBrowser(opts, fileGroup, browser, next) {
     var onTestFinish = function(err) {
+      // report mocha test failure
+      var callback = function() {
+        next(err);
+      }
       if (opts.usePromises) {
-        browser.quit().nodeify(next);
+        browser.quit().nodeify(callback);
       }
       else {
-        browser.quit(next);
+        browser.quit(callback);
       }
     };
     opts.wd = wd;


### PR DESCRIPTION
This grunt task will never fail (process exit with non-zero) if mocha test fails. which breaks the actual usage in a CI environment. For instance, command `$ grunt mochaWebdriver` will always exit with status 0. which is unexpected.

Then I found it never touches `err` parameter inside the function `onTestFinish`, which means mocha test errors are ignored. so I just simply report the mocha test result out.

I didn't provide parameter for callback function of `quit` because it kills phantom in anyway or shows "One or more tests on (Selenium|Sauce Labs) failed.". which should be caused by mocha test failure(s).
