### PR TITLE
Shortened sauce url for copyability

### DIFF
--- a/tasks/lib/mocha-sauce-reporter.js
+++ b/tasks/lib/mocha-sauce-reporter.js
@@ -39,7 +39,7 @@ module.exports = function (browser) {
         }
       }
       if (browser.mode === 'saucelabs') {
-        console.log('Test video at: http://saucelabs.com/tests/' + browser.sessionID);
+        console.log('Test video at: saucelabs.com/tests/' + browser.sessionID);
       }
       console.log();
     });


### PR DESCRIPTION
I like double-clicking the url in my terminal and then paste to the browser, but it doesn't work with the long url. It gets cut off at //saucelabs.com/tests/ so I have to drag my cursor.
