### PR TITLE
Call onClose() when already killed (#67) and bump async

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "wd": "~0.2.17",
-    "async": "~0.2.10",
+    "async": "~0.8.0",
     "mocha": "~1.18.2",
     "sauce-tunnel": "~2.0.1"
   },

--- a/tasks/grunt-mocha-wd.js
+++ b/tasks/grunt-mocha-wd.js
@@ -53,7 +53,7 @@ module.exports = function (grunt) {
       // report mocha test failure
       var callback = function() {
         next(err);
-      }
+      };
       if (opts.usePromises) {
         browser.quit().nodeify(callback);
       }
@@ -93,11 +93,24 @@ module.exports = function (grunt) {
       if (err) { return next(err); }
       browser.init(phantomCapabilities, function () {
         runTestsForBrowser(opts, fileGroup, browser, function (err) {
-          phantomProc.on('close', function () {
+
+          function onClose() {
             grunt.log.writeln('Phantom exited.');
             next(err);
-          });
-          phantomProc.kill();
+          }
+
+          // the process might be already closed due to an internal crash,
+          // so check first is already killed to avoid a deadlock.
+
+          if (phantomProc.killed) {
+            onClose();
+          } else {
+            phantomProc.on('close', function() {
+              onClose();
+            });
+
+            phantomProc.kill();
+          }
         });
       });
     });


### PR DESCRIPTION
This should fix https://github.com/jmreidy/grunt-mocha-webdriver/issues/67

Have tested it on my side, works well.

Cheers!
