### PR TITLE
Restored https link to Sauce tests

### DIFF
--- a/tasks/lib/mocha-sauce-reporter.js
+++ b/tasks/lib/mocha-sauce-reporter.js
@@ -52,7 +52,7 @@ module.exports = function (browser) {
       }
       if (browser.mode === 'saucelabs') {
         browser.sauceJobStatus(failures === 0);
-        console.log('Test video at: saucelabs.com/tests/' + browser.sessionID);
+        console.log('Test video at: https://saucelabs.com/tests/' + browser.sessionID);
       }
       console.log();
     });


### PR DESCRIPTION
I removed the https in the past without realizing there are keyboard shortcuts to open fully qualified URLs in your terminal.

I think it would be best to restore the `https` portion so that users can get to their tests faster without incurring a redirect with a protocol-less URL defaulting to `http`.

Sorry about jumping the gun on this change in the past.