### PR TITLE
allowed custom reporter for saucelabs/selenium

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,15 +14,15 @@ module.exports = function (grunt) {
 
     mochaWebdriver: {
       options: {
-        timeout: 1000 * 60 * 3,
-        reporter: 'spec'
+        timeout: 1000 * 60 * 3
       },
       phantom: {
         src: ['test/sanity.js'],
         options: {
           testName: 'phantom test',
           usePhantom: true,
-          phantomPort: 5555
+          phantomPort: 5555,
+          reporter: 'spec'
         }
       },
       phantomCapabilities: {
@@ -32,6 +32,7 @@ module.exports = function (grunt) {
           usePhantom: true,
           phantomPort: 5555,
           usePromises: true,
+          reporter: 'spec',
           // see https://github.com/detro/ghostdriver
           phantomCapabilities: {
               'phantomjs.page.settings.userAgent': 'customUserAgent',
@@ -46,6 +47,7 @@ module.exports = function (grunt) {
           usePhantom: true,
           phantomPort: 5555,
           usePromises: true,
+          reporter: 'spec',
           phantomFlags: [
             '--webdriver-logfile', 'phantom.log'
           ]
@@ -56,7 +58,8 @@ module.exports = function (grunt) {
         options: {
           testName: 'phantom test',
           usePhantom: true,
-          usePromises: true
+          usePromises: true,
+          reporter: 'spec'
         }
       },
       requires: {
@@ -64,6 +67,7 @@ module.exports = function (grunt) {
         options: {
           testName: 'phantom requires test',
           usePhantom: true,
+          reporter: 'spec',
           require: ['test/support/index.js']
         }
       },
@@ -95,7 +99,7 @@ module.exports = function (grunt) {
         }
       },
       saucePromises: {
-        src: ['test/promiseAPi.js'],
+        src: ['test/promiseAPI.js'],
         options: {
           testName: 'sauce promises test',
           concurrency: 2,
@@ -115,6 +119,20 @@ module.exports = function (grunt) {
           usePromises: true,
           browsers: [
             {browserName: 'chrome', platform: 'Windows 7', version: ''}
+          ]
+        }
+      },
+      customReporter: {
+        src: ['test/promiseAPI.js'],
+        options: {
+          tunneled: false,
+          testName: 'custom reporter test',
+          reporter: 'spec',
+          // customReporter: false, // (false is default)
+          concurrency: 1,
+          usePromises: true,
+          browsers: [
+            {browserName: 'chrome', platform: 'Windows 7', version: '36'}
           ]
         }
       },
@@ -162,7 +180,8 @@ module.exports = function (grunt) {
                                 'mochaWebdriver:requires',
                                 'mochaWebdriver:sauce',
                                 'mochaWebdriver:tunnelOptions',
-                                'mochaWebdriver:saucePromises'
+                                'mochaWebdriver:saucePromises',
+                                'mochaWebdriver:customReporter'
                               ]);
 
   grunt.registerTask('testSelenium', ['mochaWebdriver:selenium', 'mochaWebdriver:seleniumPromises']);

--- a/Readme.md
+++ b/Readme.md
@@ -64,10 +64,11 @@ Please look at this project's Gruntfile and tests to see all that in action.
 
 ###Options
 The usual Mocha options are passed through this task to a new Mocha instance.
-Please note that while it's possible to specify the Mocha reporter for
-tests running on Phantom, there's only one reporter currently supported
-for tests against Sauce Labs. This restriction is in place to handle
-concurrent Sauce Labs testing sessions, which could pollute the log.
+Please note that while it's possible to specify the Mocha `reporter` for
+tests running on Phantom and when `concurrency` is 1 on saucelabs or selenium,
+the task will default to a custom reporter if concurrency is more than 1
+and the browser is not phantom. This restriction is in place to handle concurrent
+Sauce Labs/Selenium testing sessions, which could pollute the log.
 
 The following options can be supplied to the task:
 
@@ -155,6 +156,10 @@ generated if not specified. Useful for connected to existing Sauce tunnels.
 Type: Int
 
 The number of concurrent browser sessions to spin up on Sauce Labs. Defaults to 1.
+
+####tunneled
+Type: Boolean
+A boolean value to indicate if the tunnel is to be created or not.
 
 ####tunnelFlags
 Type: Array

--- a/tasks/grunt-mocha-wd.js
+++ b/tasks/grunt-mocha-wd.js
@@ -30,6 +30,7 @@ module.exports = function (grunt) {
       testTags: [],
       build: process.env.TRAVIS_BUILD_NUMBER || process.env.BUILD_NUMBER || process.env.BUILD_TAG || process.env.CIRCLE_BUILD_NUM,
       tunnelFlags: null,
+      tunneled: true,
       secureCommands: false,
       phantomCapabilities: {},
       phantomFlags: []
@@ -193,12 +194,13 @@ module.exports = function (grunt) {
     if (opts.build) {
       browserOpts.build = opts.build;
     }
-    if (opts.identifier) {
+    if (opts.identifier && opts.tunneled) {
       browserOpts['tunnel-identifier'] = opts.identifier;
     }
 
     browser.init(browserOpts, function (err) {
       if (err) {
+        grunt.log.error(err);
         grunt.log.error('Could not initialize browser - ' + mode);
         grunt.log.error('Make sure Sauce Labs supports the following browser/platform combo' +
                         ' on ' + color('bright yellow', 'saucelabs.com/platforms') + ': ' + browserOpts.browserTitle);
@@ -235,7 +237,7 @@ module.exports = function (grunt) {
 
   function runTestsOnSaucelabs(fileGroup, opts, next) {
     if (opts.browsers) {
-      var tunnel = new SauceTunnel(opts.username, opts.key, opts.identifier, true, opts.tunnelFlags);
+      var tunnel = new SauceTunnel(opts.username, opts.key, opts.identifier, opts.tunneled, opts.tunnelFlags);
       configureLogEvents(tunnel);
 
       grunt.log.writeln("=> Connecting to Sauce Labs ...");

--- a/tasks/lib/mocha-runner.js
+++ b/tasks/lib/mocha-runner.js
@@ -21,7 +21,8 @@ module.exports = function (opts, fileGroup, browser, grunt, onTestFinish) {
     if (opts.customReporter) {
       // to allow customReporter
       // check ./mocha-sauce-reporter or https://github.com/saadtazi/gmwd-teamcity-reporter
-      opts.reporter = require(opts.reporter)(browser, opts);
+      opts.originalReporter = opts.originalReporter || opts.reporter;
+      opts.reporter = require(opts.originalReporter)(browser, opts);
     }
     
   }

--- a/tasks/lib/mocha-runner.js
+++ b/tasks/lib/mocha-runner.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Mocha = require('mocha');
+var color = Mocha.reporters.Base.color;
 var path = require('path');
 var Module = require('module');
 var generateSauceReporter = require('./mocha-sauce-reporter');
@@ -11,7 +12,16 @@ var domain = require('domain');
 module.exports = function (opts, fileGroup, browser, grunt, onTestFinish) {
   //browserTitle means we're on a SL test
   if (browser.browserTitle) {
-    opts.reporter = generateSauceReporter(browser);
+    if (opts.reporter && opts.concurrency > 1) {
+      if (!opts.customReporter) {
+        console.log(color('medium', 'ignoring "reporter" option because concurrency is > 1'));
+        opts.reporter = generateSauceReporter(browser);
+      } else {
+        // to allow customReporter
+        // check ./mocha-sauce-reporter or https://github.com/saadtazi/gmwd-teamcity-reporter
+        opts.reporter = require(opts.reporter)(browser);
+      }
+    }
   }
 
   var cwd = process.cwd();

--- a/tasks/lib/mocha-runner.js
+++ b/tasks/lib/mocha-runner.js
@@ -16,12 +16,14 @@ module.exports = function (opts, fileGroup, browser, grunt, onTestFinish) {
       if (!opts.customReporter) {
         console.log(color('medium', 'ignoring "reporter" option because concurrency is > 1'));
         opts.reporter = generateSauceReporter(browser);
-      } else {
-        // to allow customReporter
-        // check ./mocha-sauce-reporter or https://github.com/saadtazi/gmwd-teamcity-reporter
-        opts.reporter = require(opts.reporter)(browser);
       }
     }
+    if (opts.customReporter) {
+      // to allow customReporter
+      // check ./mocha-sauce-reporter or https://github.com/saadtazi/gmwd-teamcity-reporter
+      opts.reporter = require(opts.reporter)(browser, opts);
+    }
+    
   }
 
   var cwd = process.cwd();


### PR DESCRIPTION
Hi,

This PR allows to specify a custom reporter for saucelabs or selenium when concurrency == 1.
I added an undocumented feature that allows to still use a custom reporter when concurrency > 2 but that requires a grunt-mocha-webdriver custom reporter that "buffers" test run outputs. See an example of custom reporter at https://github.com/saadtazi/gmwd-teamcity-reporter (similar to mocha-sauce-reporter). To use that undocumented feature, you need to add a `customReporter: true`.

Also, I added a `tunneled`option to skip the tunnel creation: can be useful if the tested site/webapp is public.

I know, I should have split the 2 features into 2 PRs... :)

Fixes #54.