### PR TITLE
Updated selenium-launcher dependency to use git+https:// instead of git://

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "async": "^0.9.0",
     "mocha": "^1.20.0",
     "sauce-tunnel": "^2.1.0",
-    "selenium-launcher": "git://github.com/wookiehangover/nodejs-selenium-launcher.git"
+    "selenium-launcher": "git+https://github.com/wookiehangover/nodejs-selenium-launcher.git"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.10.0",


### PR DESCRIPTION
This is to address jmreidy/grunt-mocha-webdriver#86