### PR TITLE
When mocha experiences a fatal error make sure that the grunt build fails

### DIFF
--- a/tasks/lib/mocha-runner.js
+++ b/tasks/lib/mocha-runner.js
@@ -24,7 +24,7 @@ module.exports = function (opts, fileGroup, browser, grunt, onTestFinish) {
       opts.originalReporter = opts.originalReporter || opts.reporter;
       opts.reporter = require(opts.originalReporter)(browser, opts);
     }
-    
+
   }
 
   var cwd = process.cwd();
@@ -86,7 +86,6 @@ module.exports = function (opts, fileGroup, browser, grunt, onTestFinish) {
     });
   } catch (e) {
     grunt.log.error("Mocha failed to run");
-    grunt.log.error(e.stack);
-    onTestFinish(false);
+    onTestFinish(e);
   }
 };


### PR DESCRIPTION
Noticed this when we had a bad module reference in one of our spec files:
```
[4mRunning "mochaWebdriver:local" (mochaWebdriver) task [24m
Running webdriver tests against PhantomJS.
PhantomJS started.
[31m>> [39mMocha failed to run
[31m>> [39mError: Cannot find module '../../filter/filter' [31m
>> [39m  at Function.Module._resolveFilename (module.js:338:15) [31m
>> [39m  at Function.Module._load (module.js:280:25) [31m
>> [39m  at Module.require (module.js:364:17) [31m
>> [39m  at require (module.js:380:17) [31m
>> [39m  at Object.<anonymous> (/jenkins/workspace/BuzzDocs-Develop/node_modules/test-support/PAL/ToolbarList/UserNav/UserNavWithSubNavs.js:3:14) [31m
```
The error was logged to stdOut, but the build still passed.  The build needs to fail in this condition.