### PR TITLE
Using child_process.spawn over execFile to avoid buffer overflow

### DIFF
--- a/tasks/grunt-mocha-wd.js
+++ b/tasks/grunt-mocha-wd.js
@@ -125,7 +125,8 @@ module.exports = function (grunt) {
     if (opts.ignoreSslErrors) {
       phantomOpts.push('--ignore-ssl-errors', 'yes');
     }
-    var phantomProc = childProcess.execFile(phantom.path, phantomOpts);
+
+    var phantomProc = childProcess.spawn(phantom.path, phantomOpts);
     var stopPhantomProc = function() {
       phantomProc.kill();
     };


### PR DESCRIPTION
For the last couple of days my colleague (@DanForys) and I have been stumped with a rather unusual error, by which extending our codebase would cause PhantomJS to die; it turns out that the increase in data that Phantom pumped into `stdout` was causing a buffer overflow.

As explained in Hack Sparrow's post detailing [the differences between child_process.spawn and exec](http://www.hacksparrow.com/difference-between-spawn-and-exec-of-node-js-child_process.html), "child_process.exec returns the whole buffer output from the child process. By default the buffer size is set at 200k. If the child process returns anything more than that, you program will crash". `child_process.spawn` does not have this same restriction, which I imagine is down to how one references standard streams between the two methods. This single change resolved this issue for us.